### PR TITLE
Fixes silly mistake that disabled logging

### DIFF
--- a/src/main/java/com/chessmates/utility/LichessApiImpl.groovy
+++ b/src/main/java/com/chessmates/utility/LichessApiImpl.groovy
@@ -22,7 +22,7 @@ class LichessApiImpl implements LichessApi {
     static String PAGE_SIZE_GAMES = 100
     static String STARTING_PAGE = 1
 
-    private static final Logger logger = LoggerFactory.getLogger(this.getClass())
+    private static final Logger logger = LoggerFactory.getLogger(LichessApiImpl)
 
     @Autowired
     HttpUtility httpUtility

--- a/src/main/java/com/chessmates/utility/ThrottledHttpUtility.groovy
+++ b/src/main/java/com/chessmates/utility/ThrottledHttpUtility.groovy
@@ -23,7 +23,7 @@ class ThrottledHttpUtility implements HttpUtility, Cache {
     Integer COOLDOWN_TIME_MILLIS = 60000
     LocalDateTime lastRequest
 
-    private static final Logger logger = LoggerFactory.getLogger(this.getClass())
+    private static final Logger logger = LoggerFactory.getLogger(ThrottledHttpUtility)
 
     @Override
     @Cacheable("requests")


### PR DESCRIPTION
When I converted these to static properties I failled to notice
that the this context no longer made sense.