### PR TITLE
Lichess data is updated periodically

### DIFF
--- a/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
@@ -1,0 +1,37 @@
+package com.chessmates.lichess.data
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Scheduled tasks that hit the Lichess API for data.
+ */
+@Component
+class LichessDataScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(LichessDataScheduler)
+
+    LichessDataService lichessDataService
+
+    @Autowired
+    LichessDataScheduler(LichessDataService lichessDataService) {
+        this.lichessDataService = lichessDataService
+    }
+
+    @Scheduled(initialDelay = 0L, fixedDelay = 3600000L)
+    void updateData() {
+        final startTime = new Date()
+        logger.debug "Starting Lichess data update: ${startTime} (${startTime.getTime()})"
+
+        // TODO: Rename these functions, they are saving as a side affect and that isn't clear.
+        final  players = lichessDataService.getPlayers()
+        lichessDataService.getGames(players)
+
+        final endTime = new Date()
+        logger.debug "Finished Lichess data update: ${endTime} (${endTime.getTime()})"
+    }
+
+}

--- a/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
@@ -12,13 +12,8 @@ interface LichessDataService {
     /** Get all players. */
     List<Player> getPlayers()
 
-    /** Get all players up until given id. */
-    List<Player> getPlayers(String untilPlayerId)
-
     /** Get all games. */
     List<Game> getGames(List<Player> players)
 
-    /** Get all games for each player until given game. */
-    List<Game> getGames(List<Player> players, Map<ImmutablePair, Game> latestGameMap)
 
 }

--- a/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
@@ -2,6 +2,9 @@ package com.chessmates.lichess.data
 
 import com.chessmates.model.Game
 import com.chessmates.model.Player
+import com.chessmates.repository.GameRepository
+import com.chessmates.repository.MetaDataRepository
+import com.chessmates.repository.PlayerRepository
 import com.chessmates.utility.GetPageFunction
 import org.apache.commons.lang3.tuple.ImmutablePair
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,10 +28,16 @@ class LichessDataServiceImpl implements LichessDataService {
     private Integer pageSizeGames
 
     private LichessApi lichessApi
+    private PlayerRepository playerRepository
+    private GameRepository gameRepository
+    private MetaDataRepository metaDataRepository
 
     @Autowired
-    LichessDataService(LichessApi lichessApi) {
+    LichessDataService(LichessApi lichessApi, PlayerRepository playerRepository, GameRepository gameRepository, MetaDataRepository metaDataRepository) {
         this.lichessApi = lichessApi
+        this.playerRepository = playerRepository
+        this.gameRepository = gameRepository
+        this.metaDataRepository = metaDataRepository
     }
 
     /**
@@ -38,29 +47,40 @@ class LichessDataServiceImpl implements LichessDataService {
      * @return A list of all players.
      */
     @Override
-    List<Player> getPlayers(String untilPlayerId = null) {
-        def fetchPlayerPage = { String teamId, int pageNum -> lichessApi.getPlayers(teamId, pageNum, pageSizePlayers) }
-        def stopAtPlayerId = { Player player -> player.id == untilPlayerId }
+    List<Player> getPlayers() {
+        final untilPlayerId = metaDataRepository.getLatestPlayer()
+        final fetchPlayerPage = { String teamId, int pageNum -> lichessApi.getPlayers(teamId, pageNum, pageSizePlayers) }
+        final stopAtPlayerId = { Player player -> player == untilPlayerId }
 
-        def resultSet = new LichessResultSet<Player>(
+        final resultSet = new LichessResultSet<Player>(
                 (GetPageFunction)fetchPlayerPage.curry(TEAM_NAME),
                 stopAtPlayerId
         )
-        resultSet.get()
+
+        final players = resultSet.get()
+
+        players.each { playerRepository.save it }
+
+        if (players.size()) {
+            metaDataRepository.saveLatestPlayer(players.first())
+        }
+
+        return players
     }
 
     /**
      * Get only new games for each individual player combination.
      *
-     * If no map is provided all historical games will be fetched. Go get a coffee!
+     * If no store is provided all historical games will be fetched. Go get a coffee!
      *
      * @param players The players to get new games for.
-     * @param latestGameMap A map containing the latest game for each pair of opponents.
+     * @param latestGameMap A store containing the latest game for each pair of opponents.
      * @return A list of all new games.
      */
     @Override
-    List<Game> getGames(List<Player> players, Map<ImmutablePair, Game> latestGameMap = null) {
-        latestGameMap = latestGameMap ?: new HashMap<>()
+    List<Game> getGames(List<Player> players) {
+
+        final latestGameMap = metaDataRepository.getLatestGames()
 
         def fetchGamePage = { Player player, Player opponent, int pageNum ->
             lichessApi.getGames(player.id, opponent.id, pageNum, pageSizeGames) }
@@ -73,29 +93,31 @@ class LichessDataServiceImpl implements LichessDataService {
 
         def games = playerCombinations.stream()
         // Get all of the games for a pair of players.
-                .map { playerCombination ->
+            .map { playerCombination ->
 
-            def player = playerCombination.left
-            def opponent = playerCombination.right
+                def player = playerCombination.left
+                def opponent = playerCombination.right
 
-            def resultSet = new LichessResultSet<Game>(
-                    /* So functional! Bind the fetchGamePage * stop condition with the player arguments. The getAllPages func isn't concerned
-                    with any arguments. */
-                    /* PS - groovy closures! Why don't you play nice with Java 8 functions?! */
-                    (GetPageFunction)fetchGamePage.curry(player, opponent),
-                    gameIsLatest.curry(player, opponent),
-            )
+                def resultSet = new LichessResultSet<Game>(
+                        /* So functional! Bind the fetchGamePage * stop condition with the player arguments. The getAllPages func isn't concerned
+                        with any arguments. */
+                        /* PS - groovy closures! Why don't you play nice with Java 8 functions?! */
+                        (GetPageFunction)fetchGamePage.curry(player, opponent),
+                        gameIsLatest.curry(player, opponent),
+                )
 
-            def games = resultSet.get()
+                def games = resultSet.get()
 
-            if (games.size()) {
-                latestGameMap.put(playerCombination, games.first())
+                if (games.size()) {
+                    metaDataRepository.saveLatestGame(player, opponent, games.first())
+                }
+
+                return games
             }
+            .flatMap { gamePageResults -> gamePageResults.stream() }
+            .collect(Collectors.toList())
 
-            return games
-        }
-        .flatMap { gamePageResults -> gamePageResults.stream() }
-                .collect(Collectors.toList())
+        games.each { Game game -> gameRepository.save game }
 
         return games
     }

--- a/src/main/java/com/chessmates/repository/GameRepository.groovy
+++ b/src/main/java/com/chessmates/repository/GameRepository.groovy
@@ -1,0 +1,12 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Game
+
+/**
+ * Repository for Game models.
+ */
+interface GameRepository {
+    void save(Game player)
+    Game find(String playerId)
+    List<Game> findAll()
+}

--- a/src/main/java/com/chessmates/repository/MetaDataRepository.groovy
+++ b/src/main/java/com/chessmates/repository/MetaDataRepository.groovy
@@ -1,0 +1,27 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Game
+import com.chessmates.model.Player
+import com.google.common.collect.ImmutableMap
+import org.apache.commons.lang3.tuple.ImmutablePair
+
+/**
+ * A service for storing & accessing information about the current state of Lichess data.
+ */
+interface MetaDataRepository {
+
+    /** Save latest player fetched from the Lichess API. */
+    void saveLatestPlayer(Player player)
+
+    /** Get latest player fetched from the Lichess API. */
+    Player getLatestPlayer()
+
+    /** Save the latest game requested from the Lichess API for a given set of opponents. */
+    void saveLatestGame(Player player, Player opponent, Game game)
+
+    /** Get the latest game request from the Lichess API for a given set of opponents.
+     * ImmutableMap is returned to indicate that changes to this store don't affect the store contents.
+     */
+    ImmutableMap<ImmutablePair<Player, Player>, Game> getLatestGames()
+
+}

--- a/src/main/java/com/chessmates/repository/MockGameRepository.groovy
+++ b/src/main/java/com/chessmates/repository/MockGameRepository.groovy
@@ -1,0 +1,34 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Game
+import com.chessmates.model.Player
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+
+/**
+ * Repository that simply logs instead of writing to a DB.
+ */
+@Repository
+class MockGameRepository implements GameRepository {
+    Logger logger = LoggerFactory.getLogger(MockGameRepository)
+
+    Map<String, Game> store = new HashMap()
+
+    @Override
+    void save(Game game) {
+        logger.debug "(Mock) Saving game: ${game}"
+        store.put(game.id, game)
+    }
+
+    @Override
+    Game find(String gameId) {
+        logger.debug "(Mock) Fetching game: ${gameId}"
+        store.get(gameId)
+    }
+
+    @Override
+    List<Player> findAll() {
+        new ArrayList(store.values())
+    }
+}

--- a/src/main/java/com/chessmates/repository/MockLichessMetaRepository.groovy
+++ b/src/main/java/com/chessmates/repository/MockLichessMetaRepository.groovy
@@ -1,0 +1,43 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Game
+import com.chessmates.model.Player
+import com.google.common.collect.ImmutableMap
+import org.apache.commons.lang3.tuple.ImmutablePair
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+
+/**
+ * Repository that simply logs instead of writing to a DB.
+ */
+@Repository
+class MockLichessMetaRepository implements MetaDataRepository {
+    Logger logger = LoggerFactory.getLogger(MockLichessMetaRepository)
+
+    private Player latestPlayer
+    private Map<ImmutablePair<Player, Player>, Game> latestGamesForPlayers = new HashMap()
+
+    void saveLatestPlayer(Player player) {
+        logger.debug "(Mock) Saving player ${player}"
+        latestPlayer = player
+    }
+
+    Player getLatestPlayer() {
+        logger.debug "(Mock) Fetching latest player"
+        latestPlayer
+    }
+
+    void saveLatestGame(Player player, Player opponent, Game game) {
+        logger.debug "(Mock) Saving latest game: ${game} for player: ${player} opponent: ${opponent}"
+        latestGamesForPlayers.put(new ImmutablePair(player, opponent), game)
+    }
+
+    ImmutableMap<ImmutablePair<Player, Player>, Game> getLatestGames() {
+        logger.debug "(Mock) Fetching latest games"
+        ImmutableMap.builder()
+            .putAll(latestGamesForPlayers)
+            .build()
+    }
+
+}

--- a/src/main/java/com/chessmates/repository/MockPlayerRepository.groovy
+++ b/src/main/java/com/chessmates/repository/MockPlayerRepository.groovy
@@ -1,0 +1,33 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Player
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Repository
+
+/**
+ * Repository that simply logs instead of writing to a DB.
+ */
+@Repository
+class MockPlayerRepository implements PlayerRepository {
+    Logger logger = LoggerFactory.getLogger(MockPlayerRepository)
+
+    private Map<String, Player> store = new HashMap()
+
+    @Override
+    void save(Player player) {
+        logger.debug "(Mock) Saving player: ${player}"
+        store.put(player.id, player)
+    }
+
+    @Override
+    Player find(String playerId) {
+        logger.debug "(Mock) Fetching player: ${playerId}"
+        store.get(playerId)
+    }
+
+    @Override
+    List<Player> findAll() {
+        new ArrayList(store.values())
+    }
+}

--- a/src/main/java/com/chessmates/repository/PlayerRepository.groovy
+++ b/src/main/java/com/chessmates/repository/PlayerRepository.groovy
@@ -1,0 +1,14 @@
+package com.chessmates.repository
+
+import com.chessmates.model.Player
+
+/**
+ * A repository for Player models.
+ */
+interface PlayerRepository {
+
+    void save(Player player)
+    Player find(String playerId)
+    List<Player> findAll()
+
+}

--- a/src/main/java/com/chessmates/service/EntityServiceImpl.groovy
+++ b/src/main/java/com/chessmates/service/EntityServiceImpl.groovy
@@ -3,7 +3,8 @@ package com.chessmates.service
 import com.chessmates.lichess.data.LichessDataService
 import com.chessmates.model.Game
 import com.chessmates.model.Player
-
+import com.chessmates.repository.GameRepository
+import com.chessmates.repository.PlayerRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
@@ -13,25 +14,25 @@ import org.springframework.stereotype.Service
 @Service
 class EntityServiceImpl implements EntityService {
 
-    private LichessDataService lichessDataService
+    private final PlayerRepository playerRepository
+    private final GameRepository gameRepository
 
     @Autowired
-    EntityServiceImpl(LichessDataService lichessDataService) {
-        this.lichessDataService = lichessDataService
+    EntityServiceImpl(PlayerRepository playerRepository, GameRepository gameRepository) {
+        this.playerRepository = playerRepository
+        this.gameRepository = gameRepository
     }
 
     /**
      * Get all Lichess players.
      */
     @Override
-    // TODO: Replace with fetch from DB.
-    List<Player> getPlayers() { lichessDataService.getPlayers() }
+    List<Player> getPlayers() { playerRepository.findAll() }
 
     /**
      * Get all games between scott logic players.
      */
     @Override
-    // TODO: Replace with fetch from DB.
-    List<Game> getGames() { lichessDataService.getGames(getPlayers()) }
+    List<Game> getGames() { gameRepository.findAll() }
 
 }

--- a/src/main/java/com/chessmates/service/EntityServiceImpl.groovy
+++ b/src/main/java/com/chessmates/service/EntityServiceImpl.groovy
@@ -25,13 +25,13 @@ class EntityServiceImpl implements EntityService {
      */
     @Override
     // TODO: Replace with fetch from DB.
-    List<Player> getPlayers() { lichessDataService.getPlayers(null) }
+    List<Player> getPlayers() { lichessDataService.getPlayers() }
 
     /**
      * Get all games between scott logic players.
      */
     @Override
     // TODO: Replace with fetch from DB.
-    List<Game> getGames() { lichessDataService.getGames(getPlayers(), null) }
+    List<Game> getGames() { lichessDataService.getGames(getPlayers()) }
 
 }

--- a/src/test/java/com/chessmates/lichess/data/LichessResultSetTest.groovy
+++ b/src/test/java/com/chessmates/lichess/data/LichessResultSetTest.groovy
@@ -1,7 +1,5 @@
 package com.chessmates.lichess.data
 
-import com.chessmates.lichess.data.LichessResultPage
-import com.chessmates.lichess.data.LichessResultSet
 import com.chessmates.utility.GetPageFunction
 import spock.lang.Specification
 


### PR DESCRIPTION
Right so this is quite a big change, both in size and behaviour. Sorry about the size but there wasn't really an intermediary.

This adds repository interfaces, and mock repository implementations that currently use hash maps. The EntityServiceImpl now hits the repositories instead of the LichessDataService. There's a scheduled task that runs every 60 minutes (and at start up) that uses the LichessDataService, saving the new Lichess data to the repositories.

There's quite a few questions here and things that need unit testing:
* How should we handle a 429? At the moment we just throw an expception. We'll start again in 60 minutes, and start back up with whatever latest information we persisted.
* How do we handle general exceptions? We don't want unexpected errors to crash the process, and cause 60 minutes wait? Should we have a retry if it fails? What is sensible logic for that?

