### PR TITLE
Fixes issue with scheduler

### DIFF
--- a/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
@@ -1,5 +1,6 @@
 package com.chessmates.lichess.data
 
+import com.chessmates.service.EntityService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,10 +18,12 @@ class LichessDataScheduler {
     private static final Logger logger = LoggerFactory.getLogger(LichessDataScheduler)
 
     LichessDataService lichessDataService
+    EntityService entityService
 
     @Autowired
-    LichessDataScheduler(LichessDataService lichessDataService) {
+    LichessDataScheduler(LichessDataService lichessDataService, EntityService entityService) {
         this.lichessDataService = lichessDataService
+        this.entityService = entityService
     }
 
     @Scheduled(initialDelay = 0L, fixedDelay = 3600000L)
@@ -29,7 +32,9 @@ class LichessDataScheduler {
         logger.debug "Starting Lichess data update: ${startTime} (${startTime.getTime()})"
 
         // TODO: Rename these functions, they are saving as a side affect and that isn't clear.
-        final players = lichessDataService.getPlayers()
+        lichessDataService.getPlayers()
+
+        final players = entityService.getPlayers()
         lichessDataService.getGames(players)
 
         final endTime = new Date()

--- a/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataScheduler.groovy
@@ -32,10 +32,10 @@ class LichessDataScheduler {
         logger.debug "Starting Lichess data update: ${startTime} (${startTime.getTime()})"
 
         // TODO: Rename these functions, they are saving as a side affect and that isn't clear.
-        lichessDataService.getPlayers()
+        lichessDataService.updatePlayers()
 
         final players = entityService.getPlayers()
-        lichessDataService.getGames(players)
+        lichessDataService.updateGames(players)
 
         final endTime = new Date()
         logger.debug "Finished Lichess data update: ${endTime} (${endTime.getTime()})"

--- a/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
@@ -4,11 +4,12 @@ package com.chessmates.lichess.data
  */
 interface LichessDataService {
 
-    /** Get all players. */
-    List getPlayers()
+    /** Fetch all players from Lichess and persist new items. */
+    List updatePlayers()
 
-    /** Get all games. */
-    List getGames(List players)
+    /** Fetch games for given players from the Lichess and persist
+     * new items. */
+    List updateGames(List players)
 
 
 }

--- a/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
@@ -44,7 +44,7 @@ class LichessDataServiceImpl implements LichessDataService {
      * @return A list of all players.
      */
     @Override
-    List getPlayers() {
+    List updatePlayers() {
         final untilPlayer = metaDataRepository.getLatestPlayer()
         final fetchPlayerPage = { String teamId, int pageNum -> lichessApi.getPlayersPage(teamId, pageNum, pageSizePlayers) }
         final stopAtPlayerId = { player ->
@@ -80,7 +80,7 @@ class LichessDataServiceImpl implements LichessDataService {
      * @return A list of all new games.
      */
     @Override
-    List getGames(List players) {
+    List updateGames(List players) {
 
         final latestGameMap = metaDataRepository.getLatestGames()
 

--- a/src/test/java/com/chessmates/lichess/data/LichessDataSchedulerTest.groovy
+++ b/src/test/java/com/chessmates/lichess/data/LichessDataSchedulerTest.groovy
@@ -1,0 +1,34 @@
+package com.chessmates.lichess.data
+
+import com.chessmates.service.EntityService
+import spock.lang.Specification
+import spock.lang.Subject
+
+class LichessDataSchedulerTest extends Specification {
+
+    @Subject
+    LichessDataScheduler lichessDataScheduler
+
+    LichessDataService lichessDataService
+    EntityService entityService
+
+    def setup() {
+        lichessDataService = Mock(LichessDataService)
+        entityService = Mock(EntityService)
+
+        lichessDataScheduler = new LichessDataScheduler(lichessDataService, entityService)
+    }
+
+    def "Scheduler uses existing players to update games"() {
+        given:
+        final existingPlayers = [[id: 'a'], [id: 'b'], [id: 'c']]
+        entityService.getPlayers() >> existingPlayers
+
+        when:
+        lichessDataScheduler.updateData()
+
+        then:
+        1 * lichessDataService.getGames(existingPlayers)
+    }
+
+}

--- a/src/test/java/com/chessmates/lichess/data/LichessDataSchedulerTest.groovy
+++ b/src/test/java/com/chessmates/lichess/data/LichessDataSchedulerTest.groovy
@@ -28,7 +28,7 @@ class LichessDataSchedulerTest extends Specification {
         lichessDataScheduler.updateData()
 
         then:
-        1 * lichessDataService.getGames(existingPlayers)
+        1 * lichessDataService.updateGames(existingPlayers)
     }
 
 }

--- a/src/test/java/com/chessmates/lichess/data/LichessDataServiceImplTest.groovy
+++ b/src/test/java/com/chessmates/lichess/data/LichessDataServiceImplTest.groovy
@@ -148,7 +148,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.TEAM_WITH_INVALID_USERS.url) >> Helper.loadFile(Helper.TEAM_WITH_INVALID_USERS.responseFile)
 
         when:
-        final players = service.getPlayers()
+        final players = service.updatePlayers()
 
         then:
         players.size() == 1
@@ -159,7 +159,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.TEAM_WITH_EMPTY_USERS.url) >> Helper.loadFile(Helper.TEAM_WITH_EMPTY_USERS.responseFile)
 
         when:
-        final players = service.getPlayers()
+        final players = service.updatePlayers()
 
         then:
         players.size() == 0
@@ -171,7 +171,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.SCOTT_LOGIC_TEAM_2.url) >> Helper.loadFile(Helper.SCOTT_LOGIC_TEAM_2.responseFile)
 
         when:
-        final players = service.getPlayers()
+        final players = service.updatePlayers()
 
         then:
         players.size() == 8
@@ -194,7 +194,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.SCOTT_LOGIC_TEAM_2.url) >> Helper.loadFile(Helper.SCOTT_LOGIC_TEAM_2.responseFile)
 
         when:
-        final players = service.getPlayers()
+        final players = service.updatePlayers()
 
         then:
         players.size() == 5
@@ -214,7 +214,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.SCOTT_LOGIC_TEAM_2.url) >> Helper.loadFile(Helper.SCOTT_LOGIC_TEAM_2.responseFile)
 
         when:
-        service.getPlayers()
+        service.updatePlayers()
 
         then:
         1 * playerRepository.save({ it.id == 'jfaker' })
@@ -230,7 +230,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.SCOTT_LOGIC_TEAM_2.url) >> Helper.loadFile(Helper.SCOTT_LOGIC_TEAM_2.responseFile)
 
         when:
-        service.getPlayers()
+        service.updatePlayers()
 
         then:
         1 * metaDataRepository.saveLatestPlayer({ it.id == 'jfaker' })
@@ -250,7 +250,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.TF235_VS_OWENNW_INVALID.url) >> Helper.loadFile(Helper.TF235_VS_OWENNW_INVALID.responseFile)
 
         when:
-        final games = service.getGames(players)
+        final games = service.updateGames(players)
 
         then:
         games.size() == 1
@@ -264,7 +264,7 @@ class LichessDataServiceImplTest extends Specification {
         noLatestGames()
 
         when:
-        final games = service.getGames(players)
+        final games = service.updateGames(players)
 
         then:
         games.size() == 0
@@ -288,7 +288,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.OWENNW_VS_JEDRUS07_2.url) >> Helper.loadFile(Helper.OWENNW_VS_JEDRUS07_2.responseFile)
 
         when:
-        final games = service.getGames(players)
+        final games = service.updateGames(players)
 
         then:
         games.size() == 56
@@ -318,7 +318,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.OWENNW_VS_JEDRUS07_2.url) >> Helper.loadFile(Helper.OWENNW_VS_JEDRUS07_2.responseFile)
 
         when:
-        final games = service.getGames(players)
+        final games = service.updateGames(players)
 
         then:
         games.size() == 18
@@ -342,7 +342,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.OWENNW_VS_JEDRUS07_2.url) >> Helper.loadFile(Helper.OWENNW_VS_JEDRUS07_2.responseFile)
 
         when:
-        service.getGames(players)
+        service.updateGames(players)
 
         then:
         56 * gameRepository.save(_)
@@ -366,7 +366,7 @@ class LichessDataServiceImplTest extends Specification {
         httpUtility.get(Helper.OWENNW_VS_JEDRUS07_2.url) >> Helper.loadFile(Helper.OWENNW_VS_JEDRUS07_2.responseFile)
 
         when:
-        service.getGames(players)
+        service.updateGames(players)
 
         then:
         1 * metaDataRepository.saveLatestGame({ it.id == 'tf235' }, { it.id == 'owennw' }, { it.id == 'OBBHfGOC' })


### PR DESCRIPTION
The scheduler was using the newly fetched list of people
as input as to which players to fetch games for. Since the
newly fetched list != the total list of players, we weren't
updating games for existing players.