### PR TITLE
WIP: Adds thin player model wrapping JSON data

### DIFF
--- a/src/main/java/com/chessmates/Application.groovy
+++ b/src/main/java/com/chessmates/Application.groovy
@@ -1,5 +1,7 @@
 package com.chessmates
 
+import com.chessmates.model.LichessModel
+import com.chessmates.model.LichessModelSerializer
 import com.chessmates.utility.DisableSSL
 import com.google.common.cache.CacheBuilder
 import jdk.nashorn.internal.runtime.regexp.joni.Config
@@ -8,12 +10,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.guava.GuavaCache
 import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -74,6 +78,17 @@ class Application {
         def simpleCacheManager = new SimpleCacheManager()
         simpleCacheManager.setCaches(Arrays.asList(springCache))
         return simpleCacheManager
+    }
+
+    @Bean
+    Jackson2ObjectMapperBuilderCustomizer addCustomSerializers() {
+        new Jackson2ObjectMapperBuilderCustomizer() {
+
+            @Override
+            void customize(Jackson2ObjectMapperBuilder jacksonObjectMapperBuilder) {
+                jacksonObjectMapperBuilder.serializerByType(LichessModel, new LichessModelSerializer())
+            }
+        }
     }
 
 }

--- a/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataService.groovy
@@ -1,4 +1,7 @@
 package com.chessmates.lichess.data
+
+import com.chessmates.model.Player
+
 /**
  * Service for fetching data from the Lichess API.
  */

--- a/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
@@ -60,7 +60,7 @@ class LichessDataServiceImpl implements LichessDataService {
 
         List players = resultSet.get()
                 .stream()
-                .map(Player.metaClass.&invokeConstructor) // Gross - definitely worse than Java 8
+                .map({p -> Player.createPlayer(p)})
                 .filter(LichessEntityValidator.&isValid)
                 .collect(Collectors.toList())
 

--- a/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
+++ b/src/main/java/com/chessmates/lichess/data/LichessDataServiceImpl.groovy
@@ -1,5 +1,6 @@
 package com.chessmates.lichess.data
 
+import com.chessmates.model.Player
 import com.chessmates.repository.GameRepository
 import com.chessmates.repository.MetaDataRepository
 import com.chessmates.repository.PlayerRepository
@@ -59,6 +60,7 @@ class LichessDataServiceImpl implements LichessDataService {
 
         List players = resultSet.get()
                 .stream()
+                .map(Player.metaClass.&invokeConstructor) // Gross - definitely worse than Java 8
                 .filter(LichessEntityValidator.&isValid)
                 .collect(Collectors.toList())
 

--- a/src/main/java/com/chessmates/model/LichessModel.groovy
+++ b/src/main/java/com/chessmates/model/LichessModel.groovy
@@ -1,0 +1,11 @@
+package com.chessmates.model
+
+/**
+ * A lichess model object.
+ *
+ * All lichess model objects are just wrappers around the slurped JSON structure.
+ */
+interface LichessModel {
+    /** The underlying slurped JSON structure. */
+    Map slurpedJson
+}

--- a/src/main/java/com/chessmates/model/LichessModelSerializer.groovy
+++ b/src/main/java/com/chessmates/model/LichessModelSerializer.groovy
@@ -1,0 +1,16 @@
+package com.chessmates.model
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+
+/**
+ * Serializes the underlying json of a LichessModel.
+ */
+class LichessModelSerializer extends JsonSerializer<LichessModel> {
+    /** Simply returned the wrapped json. */
+    @Override
+    void serialize(LichessModel value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeObject(value.slurpedJson)
+    }
+}

--- a/src/main/java/com/chessmates/model/Player.groovy
+++ b/src/main/java/com/chessmates/model/Player.groovy
@@ -1,0 +1,24 @@
+package com.chessmates.model
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+
+/**
+ * A model object wrapping the Lichess Player response.
+ *
+ * The purpose of this class is to encapsulate the accessors we use into the returned Lichess data. We don't modify the model
+ * returned by lichess, but at the same time we don't want to have to make wide spread changes to our code base should Lichess
+ * change their structure.
+ */
+@JsonSerialize(contentUsing = LichessModelSerializer)
+class Player implements LichessModel {
+
+    final Map slurpedJson
+
+    Player(Map slurpedJson) {
+        this.slurpedJson = slurpedJson
+    }
+
+    String getId() { this.slurpedJson?.id }
+    String getUsername() { this.slurpedJson?.username }
+
+}

--- a/src/main/java/com/chessmates/model/Player.groovy
+++ b/src/main/java/com/chessmates/model/Player.groovy
@@ -18,6 +18,10 @@ class Player implements LichessModel {
         this.slurpedJson = slurpedJson
     }
 
+    static Player createPlayer(Map slurpedJson){
+        new Player(slurpedJson)
+    }
+
     String getId() { this.slurpedJson?.id }
     String getUsername() { this.slurpedJson?.username }
 


### PR DESCRIPTION
Resolves #56.

We were accessing our Lichess json data in multiple places in our
application. This is a source of change and is in multiple places
throughout the application. We still want to provide the full data to
our consumers so we wrap this data and provide accessors into it
as part of our model.

Result: changes by Lichess.com only affect the lichess class (and
our consumers - but who cares about them anyway?)

Note that we're still dynamically accessing the properties on this player object
as I haven't updated any of the code to use strong typing.

Don't merge this as I still want to add the games model & tests too.
